### PR TITLE
Improve error messages when running on Linux or on Windows within system folder

### DIFF
--- a/src/main/java/com/uipath/uipathpackage/UiPathDeploy.java
+++ b/src/main/java/com/uipath/uipathpackage/UiPathDeploy.java
@@ -147,6 +147,10 @@ public class UiPathDeploy extends Recorder implements SimpleBuildStep {
         FilePath tempRemoteDir = tempDir(workspace);
         tempRemoteDir.mkdirs();
 
+        if (launcher.isUnix()) {
+            throw new AbortException(com.uipath.uipathpackage.Messages.GenericErrors_MustUseWindows());
+        }
+
         try {
             EnvVars envVars = run.getEnvironment(listener);
 
@@ -175,11 +179,7 @@ public class UiPathDeploy extends Recorder implements SimpleBuildStep {
                 deployOptions.setEnvironments(new ArrayList<>());
             }
 
-            int result = util.execute("deploy", deployOptions, tempRemoteDir, listener, envVars, launcher);
-
-            if (result != 0) {
-                throw new AbortException("Failed to run the command");
-            }
+            util.execute("DeployOptions", deployOptions, tempRemoteDir, listener, envVars, launcher, true);
         } catch (URISyntaxException e) {
             e.printStackTrace(logger);
             throw new AbortException(e.getMessage());

--- a/src/main/java/com/uipath/uipathpackage/UiPathPack.java
+++ b/src/main/java/com/uipath/uipathpackage/UiPathPack.java
@@ -86,6 +86,10 @@ public class UiPathPack extends Builder implements SimpleBuildStep {
         FilePath tempRemoteDir = tempDir(workspace);
         tempRemoteDir.mkdirs();
 
+        if (launcher.isUnix()) {
+            throw new AbortException(com.uipath.uipathpackage.Messages.GenericErrors_MustUseWindows());
+        }
+
         try {
             EnvVars envVars = run.getEnvironment(listener);
 
@@ -117,10 +121,7 @@ public class UiPathPack extends Builder implements SimpleBuildStep {
                 util.setCredentialsFromCredentialsEntry(credentials, packOptions, run);
             }
 
-            int result = util.execute("pack", packOptions, tempRemoteDir, listener, envVars, launcher);
-            if (result != 0) {
-                throw new AbortException("Failed to run the command");
-            }
+            util.execute("PackOptions", packOptions, tempRemoteDir, listener, envVars, launcher, true);
         } catch (URISyntaxException e) {
             e.printStackTrace(listener.getLogger());
             throw new AbortException(e.getMessage());

--- a/src/main/java/com/uipath/uipathpackage/UiPathTest.java
+++ b/src/main/java/com/uipath/uipathpackage/UiPathTest.java
@@ -94,6 +94,10 @@ public class UiPathTest extends Recorder implements SimpleBuildStep, JUnitTask {
         FilePath tempRemoteDir = tempDir(workspace);
         tempRemoteDir.mkdirs();
 
+        if (launcher.isUnix()) {
+            throw new AbortException(com.uipath.uipathpackage.Messages.GenericErrors_MustUseWindows());
+        }
+
         try {
             ResourceBundle rb = ResourceBundle.getBundle("config");
             EnvVars envVars = run.getEnvironment(listener);
@@ -145,7 +149,7 @@ public class UiPathTest extends Recorder implements SimpleBuildStep, JUnitTask {
 
             util.setCredentialsFromCredentialsEntry(credentials, testOptions, run);
 
-            int result = util.execute("test", testOptions, tempRemoteDir, listener, envVars, launcher);
+            int result = util.execute("RunTestsOptions", testOptions, tempRemoteDir, listener, envVars, launcher, false);
 
             if (result != 0 && !expandedTestResultsOutputPath.exists()) {
                 throw new AbortException("Failed to run the command");

--- a/src/main/resources/com/uipath/uipathpackage/Messages.properties
+++ b/src/main/resources/com/uipath/uipathpackage/Messages.properties
@@ -12,6 +12,7 @@ GenericErrors.MissingOrchestratorAddress=Orchestrator address is mandatory
 GenericErrors.MissingFolderName=Orchestrator folder name is mandatory
 GenericErrors.MissingVersioningMethod=You must specify a versioning method
 GenericErrors.MustUseSlavePaths=Paths containing JENKINS_HOME are not allowed, you must use a path on the build agent.
+GenericErrors.MustUseWindows=Running on non-Windows operating systems is currently not supported for UiPath build steps.
 UserPassAuthenticationEntry.DisplayName=Authenticate to an On-Premise Orchestrator using a username and a password
 TokenAuthenticationEntry.DisplayName=Authenticate to a Cloud Orchestrator using a refresh token
 AutoEntry.DescriptorImpl.DisplayName=Auto generate the package version

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -1,3 +1,3 @@
-UiPath.CLI.Version=1.0.7573.25446
+UiPath.CLI.Version=1.0.7613.29514
 UiPath.DefaultTenant=default
 UiPath.CLI.Name=UiPath.CLI

--- a/src/test/java/com/uipath/uipathpackage/UiPathPackTests.java
+++ b/src/test/java/com/uipath/uipathpackage/UiPathPackTests.java
@@ -115,7 +115,7 @@ public class UiPathPackTests {
         builder.setOrchestratorTenant(orchestratorTenant);
         builder.setOutputType(outputType);
 
-        jenkins.assertLogContains(String.format("Packing project at path %s", projectJsonPath), build);
+        jenkins.assertLogContains(String.format("Packing project(s) at path %s", projectJsonPath), build);
         jenkins.assertLogContains(String.format("saved to %s", outputPath), build);
         assertThat(new File(outputPath).exists(), CoreMatchers.is(true));
     }
@@ -132,7 +132,7 @@ public class UiPathPackTests {
         doNothing().when(util).validateParams(isA(String.class), isA(String.class));
         project.getBuildersList().add(builder);
         FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
-        jenkins.assertLogContains(String.format("Packing project at path %s", parentProjectPath), build);
+        jenkins.assertLogContains(String.format("Packing project(s) at path %s", parentProjectPath), build);
         jenkins.assertLogContains(String.format("saved to %s", outputPath), build);
     }
 
@@ -151,7 +151,7 @@ public class UiPathPackTests {
         project.getBuildersList().add(builder);
         FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
         FilePath workspace = project.getSomeBuildWithWorkspace().getWorkspace();
-        jenkins.assertLogContains(String.format("Packing project at path %s", workspace != null ? workspace.child("TestProject").getRemote() : null), build);
+        jenkins.assertLogContains(String.format("Packing project(s) at path %s", workspace != null ? workspace.child("TestProject").getRemote() : null), build);
         jenkins.assertLogContains(String.format("saved to %s", workspace != null ? workspace.child("Output").getRemote() : null), build);
     }
 
@@ -167,7 +167,7 @@ public class UiPathPackTests {
         project.getBuildersList().add(builder);
         doNothing().when(util).validateParams(isA(String.class), isA(String.class));
         FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
-        jenkins.assertLogContains(String.format("Packing project at path %s", projectPath), build);
+        jenkins.assertLogContains(String.format("Packing project(s) at path %s", projectPath), build);
         jenkins.assertLogContains(String.format("saved to %s", outputPath), build);
     }
 
@@ -183,7 +183,7 @@ public class UiPathPackTests {
         project.getBuildersList().add(builder);
         doNothing().when(util).validateParams(isA(String.class), isA(String.class));
         FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
-        jenkins.assertLogContains(String.format("Packing project at path %s", projectPath), build);
+        jenkins.assertLogContains(String.format("Packing project(s) at path %s", projectPath), build);
         jenkins.assertLogNotContains(workspaceOutputPath, build);
     }
 
@@ -199,7 +199,7 @@ public class UiPathPackTests {
         project.getBuildersList().add(builder);
         doNothing().when(util).validateParams(isA(String.class), isA(String.class));
         FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
-        jenkins.assertLogContains(String.format("Packing project at path %s", projectPath), build);
+        jenkins.assertLogContains(String.format("Packing project(s) at path %s", projectPath), build);
         jenkins.assertLogNotContains(workspaceOutputPath, build);
     }
 
@@ -218,7 +218,7 @@ public class UiPathPackTests {
         project.getBuildersList().add(builder);
         doNothing().when(util).validateParams(isA(String.class), isA(String.class));
         FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
-        jenkins.assertLogContains(String.format("Packing project at path %s", projectPath), build);
+        jenkins.assertLogContains(String.format("Packing project(s) at path %s", projectPath), build);
         jenkins.assertLogNotContains(workspaceOutputPath, build);
     }
 

--- a/src/test/java/com/uipath/uipathpackage/UiPathTestTests.java
+++ b/src/test/java/com/uipath/uipathpackage/UiPathTestTests.java
@@ -150,7 +150,7 @@ public class UiPathTestTests {
        project.getPublishersList().add(publisher);
        FreeStyleBuild build = jenkins.assertBuildStatus(Result.UNSTABLE, project.scheduleBuild2(0));
 
-       jenkins.assertLogContains("Started test set Jenkins", build);
+       jenkins.assertLogContains("Started test set CI_", build);
        jenkins.assertLogContains("Writing test results of type junit", build);
        jenkins.assertLogContains("workspace\\freeStyleProject1\\results.xml", build);
 
@@ -163,7 +163,7 @@ public class UiPathTestTests {
         project.getPublishersList().add(publisher);
         FreeStyleBuild build = jenkins.assertBuildStatus(Result.SUCCESS, project.scheduleBuild2(0));
 
-        jenkins.assertLogContains("Started test set Jenkins", build);
+        jenkins.assertLogContains("Started test set CI_", build);
         jenkins.assertLogContains("Writing test results of type junit", build);
         jenkins.assertLogContains("workspace\\freeStyleProject1\\results.xml", build);
 


### PR DESCRIPTION
- fail gracefully when running on Linux, which we currently do not support
- fail gracefully when running from a workspace within the `C:\WINDOWS\system32` folder