### PR TITLE
[TS-1624] | Overriding testset arguments

### DIFF
--- a/src/main/java/com/uipath/uipathpackage/UiPathTest.java
+++ b/src/main/java/com/uipath/uipathpackage/UiPathTest.java
@@ -47,6 +47,7 @@ public class UiPathTest extends Recorder implements SimpleBuildStep, JUnitTask {
     private final SelectEntry testTarget;
     private final Integer timeout;
     private final String testResultsOutputPath;
+    private final String parametersFilePath;
     private String testResultIncludes;
     private final TraceLevel traceLevel;
 
@@ -140,7 +141,7 @@ public class UiPathTest extends Recorder implements SimpleBuildStep, JUnitTask {
             testOptions.setOrchestratorUrl(orchestratorAddress);
             testOptions.setOrchestratorTenant(orchestratorTenantFormatted);
             testOptions.setOrganizationUnit(envVars.expand(folderName.trim()));
-
+            testOptions.setParametersFilePath(this.parametersFilePath);
             testOptions.setTestReportType("junit");
 
             String resultsOutputPath = testResultsOutputPath != null && !testResultsOutputPath.trim().isEmpty()
@@ -280,6 +281,15 @@ public class UiPathTest extends Recorder implements SimpleBuildStep, JUnitTask {
         return traceLevel;
     }
 
+    /**
+     * parametersFilePath
+     *
+     * @return String parametersFilePath
+     */
+    public String getParametersFilePath() {
+        return parametersFilePath;
+    }
+
     private void validateParameters() throws AbortException {
         if (testTarget == null) {
             throw new InvalidParameterException(com.uipath.uipathpackage.Messages.GenericErrors_MissingTestSetOrProjectPath());
@@ -298,6 +308,10 @@ public class UiPathTest extends Recorder implements SimpleBuildStep, JUnitTask {
         credentials.validateParameters();
 
         if (testResultsOutputPath != null && testResultsOutputPath.toUpperCase().contains("${JENKINS_HOME}")) {
+            throw new AbortException(com.uipath.uipathpackage.Messages.ValidationErrors_InvalidPath());
+        }
+        
+        if (parametersFilePath != null && parametersFilePath.toUpperCase().contains("${JENKINS_HOME}")) {
             throw new AbortException(com.uipath.uipathpackage.Messages.ValidationErrors_InvalidPath());
         }
     }

--- a/src/main/java/com/uipath/uipathpackage/models/TestOptions.java
+++ b/src/main/java/com/uipath/uipathpackage/models/TestOptions.java
@@ -6,6 +6,7 @@ public class TestOptions extends AuthenticatedOptions {
     private String environment;
     private String testReportType;
     private String testReportDestination;
+    private String parametersFilePath;
     private Integer timeout;
 
     public String getEnvironment() {
@@ -54,5 +55,13 @@ public class TestOptions extends AuthenticatedOptions {
 
     public void setTestReportDestination(String testReportDestination) {
         this.testReportDestination = testReportDestination;
+    }
+
+    public String getParametersFilePath() {
+        return parametersFilePath;
+    }
+
+    public void setParametersFilePath(String parametersFilePath) {
+        this.parametersFilePath = parametersFilePath;
     }
 }

--- a/src/main/resources/com/uipath/uipathpackage/UiPathTest/config.jelly
+++ b/src/main/resources/com/uipath/uipathpackage/UiPathTest/config.jelly
@@ -54,6 +54,9 @@
     <f:entry field="testResultsOutputPath" title="${%TestResultsOutputPath}">
         <f:textbox/>
     </f:entry>
+    <f:entry field="parametersFilePath" title="${%ParametersFilePath}">
+        <f:textbox/>
+    </f:entry>
     <f:entry field="timeout" title="${%Timeout}">
         <f:textbox/>
     </f:entry>

--- a/src/main/resources/com/uipath/uipathpackage/UiPathTest/config.properties
+++ b/src/main/resources/com/uipath/uipathpackage/UiPathTest/config.properties
@@ -9,3 +9,4 @@ ChooseAuthenticationMethod=Authentication
 Timeout=Timeout (seconds)
 TestResultsOutputPath=Test results output path
 TraceLevel=Trace logging level
+ParametersFilePath=Input Parameters

--- a/src/main/resources/com/uipath/uipathpackage/help.properties
+++ b/src/main/resources/com/uipath/uipathpackage/help.properties
@@ -52,3 +52,4 @@ UiPathTest.testResultsOutputPath=Specify the output path of the test results, e.
 UiPathTest.testTarget=Specify the test execution target, a pre-existing test set on the Orchestrator or the tests in a package at a given path, which will be executed as part of a transient test set.
 UiPathTest.timeout=Specify the timeout of a test project to be deployed in Orchestrator and executed as part of a transient test set. The default value is 7200 seconds.
 UiPathTest.traceLevel=The trace logging level. One of the following values: None, Critical, Error, Warning, Information, Verbose. (default None)
+UiPathTest.parametersFilePath=Specify the location of a input parameters json file to override input arguments for a transient test set.


### PR DESCRIPTION
## Description

- Added new control in the UiPath Test task Ui to provide the file path for input parameters json.

## How to test
Prerequisite : update orchestrator client version in CLI also update the subsequent cli version in cliUtil.js (ADO) and config.properties (jenkinsci)

- run uipath test task , you will see a newer control **InputParameters** which requires json file path containing input parameters which will be overridden in the triggered test set.

## Jira
[TS-1624](https://uipath.atlassian.net/browse/TS-1624)

## Attachment
wiil attach ui screenshot as soon as preview gets published.
![image](https://user-images.githubusercontent.com/74954587/129893791-241b4aa8-1301-42d6-90db-b40ece978ae2.png)
