### PR TITLE
[TS-1649] | Added Support for Test Robots

### DIFF
--- a/src/main/java/com/uipath/uipathpackage/entries/job/TestAutomationJobTypeEntry.java
+++ b/src/main/java/com/uipath/uipathpackage/entries/job/TestAutomationJobTypeEntry.java
@@ -1,0 +1,37 @@
+package com.uipath.uipathpackage.entries.job;
+
+import javax.annotation.Nonnull;
+
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import com.uipath.uipathpackage.Messages;
+import com.uipath.uipathpackage.entries.SelectEntry;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+
+public class TestAutomationJobTypeEntry extends SelectEntry {
+	
+    /**
+     * Blank Class to represent test automation job type
+     */
+    @DataBoundConstructor
+    public TestAutomationJobTypeEntry() {
+    }
+
+    @Override
+    public boolean validateParameters() {
+        return true;
+    }
+
+    @Symbol("Test")
+    @Extension
+    public static class DescriptorImpl extends Descriptor<SelectEntry> {
+        @Nonnull
+        @Override
+        public String getDisplayName() {
+            return Messages.TestAutomationJobTypeEntry_DisplayName();
+        }
+    }
+}

--- a/src/main/resources/com/uipath/uipathpackage/Messages.properties
+++ b/src/main/resources/com/uipath/uipathpackage/Messages.properties
@@ -36,6 +36,7 @@ ExternalAppAuthenticationEntry.DisplayName=Authenticate to a Cloud Orchestrator 
 DynamicallyEntry.DisplayName=Allocate dynamically
 NonProductionJobTypeEntry.DisplayName=NonProduction
 UnattendedJobTypeEntry.DisplayName=Unattended
+TestAutomationJobTypeEntry.DisplayName=Test
 RobotEntry.DisplayName=Specific robots
 AutoEntry.DescriptorImpl.DisplayName=Auto generate the package version
 CurrentEntry.DescriptorImpl.DisplayName=Use the version specified in the project file


### PR DESCRIPTION
## Description

With 21.10 we are enabling running jobs on Orchestrator using a test robot license in the context of a non-prod environment.
With this change we should also support selecting a test robot license for our plugin within the ‘Run Job’ task.

For this we have added an extra option Test in jobType dropdown.

## Jira

https://uipath.atlassian.net/browse/TS-1649

## Testing
Perform Testing on Preview (PENDING)

## Screenshot
Will add after testing on preview