### PR TITLE
Fix/cideploycheck

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,12 +90,6 @@ stages:
 
           - bash: |
               rm jenkins-cli.jar*
-              echo 'JenkinsUrlHttp' $(JenkinsUrlHttp)
-              echo 'JenkinsUrl' $(JenkinsUrl)
-              echo 'JenkinsUsername' $(JenkinsUsername)
-              echo 'JenkinsAuthToken' $(JenkinsAuthToken)
-              echo 'AzureAccountName' $(AzureAccountName)
-              echo 'Build.BuildNumber' $(Build.BuildNumber)
               wget $(JenkinsUrl)/jnlpJars/jenkins-cli.jar
               java -verbose -jar jenkins-cli.jar -s $(JenkinsUrlHttp) -auth $(JenkinsUsername):$(JenkinsAuthToken) install-plugin https://$(AzureAccountName).blob.core.windows.net/plugins/$(Build.BuildNumber)/uipath-automation-package.hpi -restart
               timeout 300 bash -c 'while [[ "$(curl -k -s -o /dev/null -w ''%{http_code}'' $(JenkinsUrl)/login)" != "200" ]]; do echo "waiting for plugin to install" && sleep 5; done'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,7 +98,7 @@ stages:
               echo 'Build.BuildNumber' $(Build.BuildNumber)
               wget $(JenkinsUrl)/jnlpJars/jenkins-cli.jar
               java -verbose -jar jenkins-cli.jar -s $(JenkinsUrlHttp) -auth $(JenkinsUsername):$(JenkinsAuthToken) install-plugin https://$(AzureAccountName).blob.core.windows.net/plugins/$(Build.BuildNumber)/uipath-automation-package.hpi -restart
-              timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' $(JenkinsUrl)/login)" != "200" ]]; do echo "waiting for plugin to install" && sleep 5; done'
+              timeout 300 bash -c 'while [[ "$(curl -k -s -o /dev/null -w ''%{http_code}'' $(JenkinsUrl)/login)" != "200" ]]; do echo "waiting for plugin to install" && sleep 5; done'
             displayName: "Install package on Jenkins server"
 
 - template: stage.test.template.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,7 +91,7 @@ stages:
           - bash: |
               rm jenkins-cli.jar*
               wget $(JenkinsUrl)/jnlpJars/jenkins-cli.jar
-              java -verbose -jar jenkins-cli.jar -s $(JenkinsUrlHttp) -auth $(JenkinsUsername):$(JenkinsAuthToken) install-plugin https://$(AzureAccountName).blob.core.windows.net/plugins/$(Build.BuildNumber)/uipath-automation-package.hpi -restart
+              java -jar jenkins-cli.jar -s $(JenkinsUrlHttp) -auth $(JenkinsUsername):$(JenkinsAuthToken) install-plugin https://$(AzureAccountName).blob.core.windows.net/plugins/$(Build.BuildNumber)/uipath-automation-package.hpi -restart
               timeout 300 bash -c 'while [[ "$(curl -k -s -o /dev/null -w ''%{http_code}'' $(JenkinsUrl)/login)" != "200" ]]; do echo "waiting for plugin to install" && sleep 5; done'
             displayName: "Install package on Jenkins server"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,8 +90,14 @@ stages:
 
           - bash: |
               rm jenkins-cli.jar*
+              echo 'JenkinsUrlHttp' $(JenkinsUrlHttp)
+              echo 'JenkinsUrl' $(JenkinsUrl)
+              echo 'JenkinsUsername' $(JenkinsUsername)
+              echo 'JenkinsAuthToken' $(JenkinsAuthToken)
+              echo 'AzureAccountName' $(AzureAccountName)
+              echo 'Build.BuildNumber' $(Build.BuildNumber)
               wget $(JenkinsUrl)/jnlpJars/jenkins-cli.jar
-              java -jar jenkins-cli.jar -s $(JenkinsUrlHttp) -auth $(JenkinsUsername):$(JenkinsAuthToken) install-plugin https://$(AzureAccountName).blob.core.windows.net/plugins/$(Build.BuildNumber)/uipath-automation-package.hpi -restart
+              java -verbose -jar jenkins-cli.jar -s $(JenkinsUrlHttp) -auth $(JenkinsUsername):$(JenkinsAuthToken) install-plugin https://$(AzureAccountName).blob.core.windows.net/plugins/$(Build.BuildNumber)/uipath-automation-package.hpi -restart
               timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' $(JenkinsUrl)/login)" != "200" ]]; do echo "waiting for plugin to install" && sleep 5; done'
             displayName: "Install package on Jenkins server"
 


### PR DESCRIPTION
Have added the certificate ignore option while "_DeployJenkinsPlugin_" azure stage.

Reason: Considering the test servers that we use for deploying/testing the new Jenkins plugin, we should add this. The test servers that we are using, basically uses a self signed certificate and it is not possible to get those certificate installed in the virutal machine. Today, even if we were able to do it, but if in future someone changes the jenkins agent, he might not be able to get the exact resolution and can result wastage of time. So, as it is just for testing we can ignore the certificate validate option.

Tested on azure pipeline and its working correctly.