### PR TITLE
Updating the Release version and CLI version

### DIFF
--- a/src/main/java/com/uipath/uipathpackage/UiPathAssets.java
+++ b/src/main/java/com/uipath/uipathpackage/UiPathAssets.java
@@ -45,12 +45,23 @@ public class UiPathAssets extends Builder implements SimpleBuildStep {
     /**
      * Data bound constructor responsible for setting the values param values to state
      * 
-     * @param assetsAction  What to do with the assets: deploy or update.
-     * @param traceLevel    The trace logging level. One of the following values: None, Critical, Error, Warning, Information, Verbose. (default None)
+     * @param assetsAction          What to do with the assets: deploy or update.
+     * @param orchestratorAddress   Address of the orchestrator
+     * @param orchestratorTenant    Tenant on which the task needs to run
+     * @param folderName            Name of the folder in which the asset needs to updated
+     * @param credentials           credentials to make a connection
+     * @param filePath              json filePath
+     * @param traceLevel            The trace logging level. One of the following values: None, Critical, Error, Warning, Information, Verbose. (default None)
+     *
      */
     @DataBoundConstructor
-    public UiPathAssets(SelectEntry assetsAction, String orchestratorAddress, String orchestratorTenant,
-    String folderName, SelectEntry credentials, String filePath, TraceLevel traceLevel) {
+    public UiPathAssets(SelectEntry assetsAction,
+                        String orchestratorAddress,
+                        String orchestratorTenant,
+                        String folderName,
+                        SelectEntry credentials,
+                        String filePath,
+                        TraceLevel traceLevel) {
         this.assetsAction = assetsAction;
         this.orchestratorAddress = orchestratorAddress;
         this.orchestratorTenant = orchestratorTenant;

--- a/src/main/java/com/uipath/uipathpackage/UiPathRunJob.java
+++ b/src/main/java/com/uipath/uipathpackage/UiPathRunJob.java
@@ -65,6 +65,7 @@ public class UiPathRunJob extends Recorder implements SimpleBuildStep {
      * @param parametersFilePath    The full path to a json input file.
      * @param priority              The priority of job runs. One of the following values: Low, Normal, High. (default Normal)
      * @param strategy              Strategy
+     * @param jobType               Type of job which needs to run
      * @param resultFilePath        The full path to a json file or a folder where the result json file will be created.
      * @param timeout               The timeout for job executions in seconds. (default 1800)
      * @param failWhenJobFails      The command fails when at least one job fails. (default true)
@@ -76,23 +77,30 @@ public class UiPathRunJob extends Recorder implements SimpleBuildStep {
      * @param credentials           Orchestrator credentials
      */
     @DataBoundConstructor
-    public UiPathRunJob(String processName, String parametersFilePath, StartProcessDtoJobPriority priority, SelectEntry strategy, SelectEntry jobType, String resultFilePath,
-                        Integer timeout, Boolean failWhenJobFails, Boolean waitForJobCompletion, TraceLevel traceLevel,
-                        String orchestratorAddress, String orchestratorTenant, String folderName, SelectEntry credentials) {
+    public UiPathRunJob(String processName,
+                        String parametersFilePath,
+                        StartProcessDtoJobPriority priority,
+                        SelectEntry strategy,
+                        SelectEntry jobType,
+                        String resultFilePath,
+                        Integer timeout,
+                        Boolean failWhenJobFails,
+                        Boolean waitForJobCompletion,
+                        TraceLevel traceLevel,
+                        String orchestratorAddress,
+                        String orchestratorTenant,
+                        String folderName,
+                        SelectEntry credentials) {
         this.processName = processName;
         this.parametersFilePath = parametersFilePath;
         this.priority = priority;
         this.jobType = jobType;
-
         this.strategy = strategy;
-
         this.resultFilePath = resultFilePath;
         this.timeout = timeout;
         this.failWhenJobFails = failWhenJobFails;
         this.waitForJobCompletion = waitForJobCompletion;
-
         this.traceLevel = traceLevel;
-
         this.orchestratorAddress = orchestratorAddress;
         this.orchestratorTenant = orchestratorTenant;
         this.credentials = credentials;

--- a/src/main/java/com/uipath/uipathpackage/UiPathTest.java
+++ b/src/main/java/com/uipath/uipathpackage/UiPathTest.java
@@ -68,13 +68,15 @@ public class UiPathTest extends Recorder implements SimpleBuildStep, JUnitTask {
     /**
      * Data bound constructor responsible for setting the values param values to state
      *
-     * @param orchestratorAddress  UiPath Orchestrator base URL
-     * @param orchestratorTenant   UiPath Orchestrator tenant
-     * @param testTarget           Test target
-     * @param credentials          UiPath Orchestrator credentials
+     * @param orchestratorAddress   UiPath Orchestrator base URL
+     * @param orchestratorTenant    UiPath Orchestrator tenant
+     * @param folderName            Folder Name
+     * @param testTarget            Test target
+     * @param credentials           UiPath Orchestrator credentials
      * @param testResultsOutputPath Test result output path (JUnit format)
-     * @param timeout              Timeout
+     * @param timeout               Timeout
      * @param traceLevel            The trace logging level. One of the following values: None, Critical, Error, Warning, Information, Verbose. (default None)
+     * @param parametersFilePath    Path of the parameter file
      */
     @DataBoundConstructor
     public UiPathTest(String orchestratorAddress, String orchestratorTenant, String folderName, SelectEntry testTarget, SelectEntry credentials, String testResultsOutputPath, Integer timeout, TraceLevel traceLevel, String parametersFilePath)  {
@@ -319,7 +321,7 @@ public class UiPathTest extends Recorder implements SimpleBuildStep, JUnitTask {
     /**
      * attachRobotLogs
      *
-     * @param boolean attachRobotLogs
+     * @param attachRobotLogs   Boolean field whether to attach the robot logs
      */
     @DataBoundSetter
     public void setAttachRobotLogs(boolean attachRobotLogs) {

--- a/src/main/java/com/uipath/uipathpackage/entries/authentication/ExternalAppAuthenticationEntry.java
+++ b/src/main/java/com/uipath/uipathpackage/entries/authentication/ExternalAppAuthenticationEntry.java
@@ -33,10 +33,11 @@ public class ExternalAppAuthenticationEntry extends SelectEntry {
 
     /**
      * Constructs a new instance of an external application authentication entry
-     * @param accountForApp The account name
-     * @param applicationId The external application id
+     * @param accountForApp     The account name
+     * @param applicationId     The external application id
      * @param applicationSecret The external application secret
-     * @param applicationScope The external application scope(s)
+     * @param applicationScope  The external application scope(s)
+     * @param identityUrl       IdentityUrl in case of paas environment
      */
     @DataBoundConstructor
     public ExternalAppAuthenticationEntry(String accountForApp, String applicationId, String applicationSecret, String applicationScope, String identityUrl) {

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -1,3 +1,3 @@
-UiPath.CLI.Version=1.0.8063.26639
+UiPath.CLI.Version=1.0.8136.25036
 UiPath.DefaultTenant=default
 UiPath.CLI.Name=UiPath.CLI


### PR DESCRIPTION
### Description
If the process has the default entry point and the user is given the "Main. xaml" entry point then the deploy task fails saying "Package Already exists". The reason behind this is, that we always consider the default entry point as "Main.xaml" and while deploying we do not check for any process created with a null entry point, hence we use the same name which already exists in the orchestrator and hence the error.

### JIRA
[https://uipath.atlassian.net/browse/TS-1852](https://uipath.atlassian.net/browse/TS-1852) : Deploy fails with error 'package already exists'

### Testing
I have tried to update the process which has a default entry point and it is successful. Also, other normal happy workflows have been tested with unit tests.

### Screenshot
![image](https://user-images.githubusercontent.com/88530400/162762532-5bd47963-69de-4a82-b614-e5d97a089250.png)
