### PR TITLE
Updating the windows latest images for build pipeline

### DIFF
--- a/.vsts-ci-security.yml
+++ b/.vsts-ci-security.yml
@@ -16,7 +16,7 @@ stages:
     - job: BuildAndScan
       displayName: Build and Security Scan
       pool:
-        vmImage: vs2017-win2016
+        vmImage: windows-latest
         demands:
           - maven 
       steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ stages:
     variables:
       MavenPOMFile: '$(Build.SourcesDirectory)/pom.xml'
     pool:
-      vmImage: vs2017-win2016
+      vmImage: windows-latest
       demands:
         - maven
     steps:

--- a/stage.security.yml
+++ b/stage.security.yml
@@ -2,7 +2,7 @@ jobs:
 - deployment: BuildAndScan
   displayName: Build and Security Scan
   pool:
-    vmImage: vs2017-win2016
+    vmImage: windows-latest
     demands:
       - maven
   environment: Security-Scan


### PR DESCRIPTION
### Description
We need to rectify below issue of build agent. Build Agent 2016 is deprecated and we should use the latest one.

`[error]This is a scheduled windows-2016 brownout. The windows-2016 environment is deprecated and will be removed on April 1st, 2022. For more details, see https://github.com/actions/virtual-environments/issues/5238 ,##[error]The remote provider was unable to process the request.`

### Jira
https://uipath.atlassian.net/browse/TS-1874
https://uipath.atlassian.net/browse/TS-1879

### Testing
Tested in the pipeline and pipeline is successful
