### PR TITLE
Updating the Jenkins file to use the Java 11 for Jenkins CI Build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,6 @@
-buildPlugin(tests: [skip: true], platforms: ['windows'])
+buildPlugin(
+    tests: [skip: true],
+    configurations: [
+        [platform: 'windows', jdk: '11', jenkins: '2.361.2'],
+      ]
+)


### PR DESCRIPTION
### Description 
With the new change from Jenkins and with the usage of LTS in our plugin, we need to use Java 11 for the build, for both the internal pipeline and the pipeline on the Jenkins side. Internally we have made this change, but this PR addressed the change for the Jenkins pipeline on their side.

![image](https://user-images.githubusercontent.com/88530400/221107120-ecb8d944-ba8c-46a9-ac85-ed35feabf420.png)

### Relevant Jira
https://uipath.atlassian.net/browse/TS-2102 Add support for Java 11 for Jenkins internal pipeline