### PR TITLE
feat: pass governance file for analyze [AUOPS-3285]

### DIFF
--- a/src/main/java/com/uipath/uipathpackage/UiPathPack.java
+++ b/src/main/java/com/uipath/uipathpackage/UiPathPack.java
@@ -56,6 +56,7 @@ public class UiPathPack extends Builder implements SimpleBuildStep {
     private String orchestratorTenant;
     private SelectEntry credentials;
     private final TraceLevel traceLevel;
+    private String governanceFilePath;
 
     /**
      * Data bound constructor responsible for setting the values param values to state
@@ -85,6 +86,7 @@ public class UiPathPack extends Builder implements SimpleBuildStep {
         this.orchestratorTenant = "";
         this.credentials = null;
         this.runWorkflowAnalysis = false;
+        this.governanceFilePath = null;
     }
 
     /**
@@ -129,6 +131,12 @@ public class UiPathPack extends Builder implements SimpleBuildStep {
 
             if (runWorkflowAnalysis) {
                 AnalyzeOptions analyzeOptions = new AnalyzeOptions();
+                if (governanceFilePath != null && !governanceFilePath.isEmpty()) {
+                    FilePath expandedGovernanceFilePath = governanceFilePath.contains("${WORKSPACE}") ?
+                            new FilePath(launcher.getChannel(), envVars.expand(governanceFilePath)) :
+                            workspace.child(envVars.expand(governanceFilePath));
+                    analyzeOptions.setGovernanceFilePath(expandedGovernanceFilePath.getRemote());
+                }
                 if (disableBuiltInNugetFeeds != null && disableBuiltInNugetFeeds) {
                     analyzeOptions.setDisableBuiltInNugetFeeds(true);
                 }
@@ -218,6 +226,11 @@ public class UiPathPack extends Builder implements SimpleBuildStep {
             this.orchestratorTenant = null;
             this.credentials = null;
         }
+    }
+
+    @DataBoundSetter
+    public void setGovernanceFilePath(String governanceFilePath) {
+        this.governanceFilePath = governanceFilePath;
     }
 
     @DataBoundSetter
@@ -377,6 +390,10 @@ public class UiPathPack extends Builder implements SimpleBuildStep {
      */
     public boolean getRunWorkflowAnalysis() {
         return runWorkflowAnalysis;
+    }
+
+    public String getGovernanceFilePath() {
+        return governanceFilePath;
     }
 
     /**

--- a/src/main/java/com/uipath/uipathpackage/models/AnalyzeOptions.java
+++ b/src/main/java/com/uipath/uipathpackage/models/AnalyzeOptions.java
@@ -2,11 +2,12 @@ package com.uipath.uipathpackage.models;
 
 public class AnalyzeOptions extends CommonOptions {
     private String projectPath;
-    private String analyzerTraceLevel = "Verbose";
+    private String analyzerTraceLevel;
     private boolean stopOnRuleViolation = true;
     private boolean treatWarningsAsErrors = false;
     private String ignoredRules = "";
     private Boolean disableBuiltInNugetFeeds;
+    private String governanceFilePath;
 
     public boolean isDisableBuiltInNugetFeeds() {
         return disableBuiltInNugetFeeds;
@@ -54,5 +55,13 @@ public class AnalyzeOptions extends CommonOptions {
 
     public void setIgnoredRules(String ignoredRules) {
         this.ignoredRules = ignoredRules;
+    }
+
+    public String getGovernanceFilePath() {
+        return governanceFilePath;
+    }
+
+    public void setGovernanceFilePath(String governanceFilePath) {
+        this.governanceFilePath = governanceFilePath;
     }
 }

--- a/src/main/java/com/uipath/uipathpackage/models/DeployOptions.java
+++ b/src/main/java/com/uipath/uipathpackage/models/DeployOptions.java
@@ -7,7 +7,7 @@ public class DeployOptions extends CommonOptions {
     private List<String> environments;
     private List<String> entryPointPaths;
     private boolean createProcess;
-    private boolean ignoreLibraryDeployConflict;
+    private Boolean ignoreLibraryDeployConflict = null;
 
     public String getPackagesPath() {
         return packagesPath;

--- a/src/main/resources/com/uipath/uipathpackage/UiPathPack/config.jelly
+++ b/src/main/resources/com/uipath/uipathpackage/UiPathPack/config.jelly
@@ -57,6 +57,9 @@
     <f:entry title="${%RunWorkflowAnalysis}" field="runWorkflowAnalysis">
         <f:checkbox default="false"/>
     </f:entry>
+    <f:entry title="${%GovernanceFilePath}" field="governanceFilePath">
+        <f:textbox default=""/>
+    </f:entry>
     <f:optionalBlock title="${%PackageMetadata}" field="showMetadata" checked="${instance.showMetadata}" inline="true">
         <f:entry field="repositoryUrl" title="${%RepositoryUrl}">
             <f:textbox/>

--- a/src/main/resources/com/uipath/uipathpackage/UiPathPack/config.properties
+++ b/src/main/resources/com/uipath/uipathpackage/UiPathPack/config.properties
@@ -17,3 +17,4 @@ ProjectUrl=Automation Hub Idea URL
 ReleaseNotes=Release notes
 UseOrchestrator=Use Orchestrator feed when packaging libraries
 TraceLevel=Trace logging level
+GovernanceFilePath=Governance file path

--- a/stage.test.yml
+++ b/stage.test.yml
@@ -41,7 +41,7 @@ stages:
         #### UiPathInstallPlatform E2E tests ###
         - jobName: 'InstallPrePackagedCLI'
           configurationName: 'JenkinsE2ETests/UiPathInstallPlatform/InstallPrePackagedCLI'
-          dependsOnJob: 'DeployEntryPointPaths'
+          dependsOnJob: 'IgnoreLibraryDeployConflict'
         - jobName: 'InstallDownloadedCLI'
           configurationName: 'JenkinsE2ETests/UiPathInstallPlatform/InstallDownloadedCLI'
           dependsOnJob: 'InstallPrePackagedCLI'
@@ -73,10 +73,13 @@ stages:
         - jobName: 'PackShouldNotLookUpInBuiltInFeeds'
           configurationName: 'JenkinsE2ETests/UiPathPack/PackShouldNotLookUpInBuiltInFeeds'
           dependsOnJob: 'PackWithRepositoryMetadata'
+        - jobName: 'AnalyzeShouldUseGovernanceFile'
+          configurationName: 'JenkinsE2ETests/UiPathPack/AnalyzeShouldUseGovernanceFile'
+          dependsOnJob: 'PackShouldNotLookUpInBuiltInFeeds'
         #### UiPathRunJob E2E tests ###
         - jobName: 'RunJobFailsWhenORJobFails'
           configurationName: 'JenkinsE2ETests/UiPathRunJob/RunJobFailsWhenORJobFails'
-          dependsOnJob: 'PackShouldNotLookUpInBuiltInFeeds'
+          dependsOnJob: 'AnalyzeShouldUseGovernanceFile'
         - jobName: 'RunJobOnMultipleLicenseTypes'
           configurationName: 'JenkinsE2ETests/UiPathRunJob/RunJobOnMultipleLicenseTypes'
           dependsOnJob: 'RunJobFailsWhenORJobFails'


### PR DESCRIPTION
## What changed?
###### Add input parameter to optionally pass governance file that will be used during analyze.

## Why is this change necessary?
###### Enable users to have control over the WFA rules that are considered during analyze.

## How has this been tested?
Added e2e test in [tests repo](https://github.com/UiPath/CI-Plugins-Tests/tree/feat/test-pass-governance-file-AUOPS-3285).

## Are there any breaking changes?
- [x] None
- [ ] Input parameter renaming/removal
- [ ] New input parameter that changes the previous default behaviour
- [ ] Authentication option removal
- [ ] Changing the default CLI that come with breaking changes compared to the previous default CLI version