### PR TITLE
feat: onboard to automatic release procedure [AUOPS-4287]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates
+
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: monthly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,22 @@
+# Note: additional setup is required, see https://www.jenkins.io/redirect/continuous-delivery-of-plugins
+
+name: cd
+on:
+  workflow_dispatch:
+    inputs:
+      validate_only:
+        required: false
+        type: boolean
+        description: |
+          Run validation with release drafter only
+          → Skip the release job
+        default: false
+
+jobs:
+  maven-cd:
+    uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v1
+    with:
+      validate_only: ${{ inputs.validate_only == true }}
+    secrets:
+      MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+      MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.8</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,3 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals
+-Dchangelist.format=%d.v%s

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 buildPlugin(
     tests: [skip: true],
     configurations: [
-        [platform: 'windows', jdk: '11', jenkins: '2.361.2'],
+        [platform: 'windows', jdk: '11', jenkins: '2.414.3'],
       ]
 )

--- a/pom.xml
+++ b/pom.xml
@@ -9,10 +9,13 @@
     </parent>
 
     <artifactId>uipath-automation-package</artifactId>
-    <version>4.0-SNAPSHOT</version>
+    <version>${revision}.${changelist}</version>
     <packaging>hpi</packaging>
 
     <properties>
+        <revision>4.0</revision>
+        <changelist>999999-SNAPSHOT</changelist>
+        <gitHubRepo>jenkinsci/uipath-automation-package-plugin</gitHubRepo>
         <jenkins.version>2.414.3</jenkins.version>
         <powershell.version>1.7</powershell.version>
         <envinject.version>2.4.0</envinject.version>
@@ -212,10 +215,10 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:ssh://git@github.com/jenkinsci/uipath-automation-package-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/uipath-automation-package-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/uipath-automation-package-plugin</url>
-        <tag>HEAD</tag>
+        <connection>scm:git:ssh://git@github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/${gitHubRepo}.git</developerConnection>
+        <url>https://github.com/${gitHubRepo}</url>
+        <tag>${scmTag}</tag>
     </scm>
     <!-- List of dependencies of the project. -->
     <dependencies>
@@ -391,7 +394,7 @@
             </roles>
         </developer>
         <developer>
-            <id>cotovanu-cristian</id>
+            <id>cristiancotovanu</id>
             <name>Cristian Cotovanu</name>
             <url>https://github.com/cotovanu-cristian</url>
             <email>cristian.cotovanu@uipath.com</email>


### PR DESCRIPTION
## What changed?
- add cd github workflow for automatic release with manually controlled prefix (https://www.jenkins.io/doc/developer/publishing/releasing-cd/#update-maven-pom-and-config)
- upgrade jenkins version used in Jenkinsfile for CI
- enable dependabot (https://www.jenkins.io/doc/developer/publishing/releasing-cd/#update-maven-pom-and-config)
- enable incrementals (https://www.jenkins.io/doc/developer/plugin-development/incrementals/)
- enable jenkins security scan (https://www.jenkins.io/doc/developer/security/scan/) -- unfortunately this won't work in the current state as we are running a powershell script and the scan template build is being done on linux agents

## Why is this change necessary?
Improve release procedure

## How has this been tested?
On PR

## Are there any breaking changes?
- [x] None
- [ ] Input parameter renaming/removal
- [ ] New input parameter that changes the previous default behaviour
- [ ] Authentication option removal
- [ ] Changing the default CLI that come with breaking changes compared to the previous default CLI version