### PR TITLE
chore: change pwsh to be OS agnostic instead of powershell.exe windows only

### DIFF
--- a/.github/workflows/jenkins-security-scan.yml
+++ b/.github/workflows/jenkins-security-scan.yml
@@ -1,0 +1,21 @@
+name: Jenkins Security Scan
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+  workflow_dispatch:
+
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+
+jobs:
+  security-scan:
+    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
+    with:
+      java-cache: 'maven' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.
+      java-version: 11 # Optionally specify what version of Java to set up for the build, or remove to use a recent default.

--- a/pom.xml
+++ b/pom.xml
@@ -122,8 +122,8 @@
                         </goals>
                         <configuration>
                             <target>
-                                <exec executable="powershell.exe">
-                                    <arg value=".\GenerateHelpFiles.ps1 " />
+                                <exec executable="pwsh">
+                                    <arg value=".\GenerateHelpFiles.ps1 "/>
                                 </exec>
                             </target>
                         </configuration>


### PR DESCRIPTION
## What changed?
Change executable to pwsh to be OS agnostic instead of `powershell.exe` windows exclusive

## Why is this change necessary?
To unblock release cd.yaml

## How has this been tested?
PR build on linux agent from security scan.

## Are there any breaking changes?
- [X] None
- [ ] Input parameter renaming/removal
- [ ] New input parameter that changes the previous default behaviour
- [ ] Authentication option removal
- [ ] Changing the default CLI that come with breaking changes compared to the previous default CLI version