### PR TITLE
Merge OS agnostic changes for release v4.0

### DIFF
--- a/.github/workflows/jenkins-security-scan.yml
+++ b/.github/workflows/jenkins-security-scan.yml
@@ -1,0 +1,21 @@
+name: Jenkins Security Scan
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+  workflow_dispatch:
+
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+
+jobs:
+  security-scan:
+    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
+    with:
+      java-cache: 'maven' # Optionally enable use of a build dependency cache. Specify 'maven' or 'gradle' as appropriate.
+      java-version: 11 # Optionally specify what version of Java to set up for the build, or remove to use a recent default.

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <symbol-annotation.version>1.23</symbol-annotation.version>
         <junit.junit.version>4.13.2</junit.junit.version>
         <localization-support.version>1.2</localization-support.version>
-        <snakeyaml.version>2.0</snakeyaml.version>
+        <snakeyaml.version>2.3</snakeyaml.version>
         <structs.version>325.vcb_307d2a_2782</structs.version>
         <caffeine-api.version>3.1.8-133.v17b_1ff2e0599</caffeine-api.version>
         <instance-identity.version>201.vd2a_b_5a_468a_a_6</instance-identity.version>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <structs.version>325.vcb_307d2a_2782</structs.version>
         <caffeine-api.version>3.1.8-133.v17b_1ff2e0599</caffeine-api.version>
-        <instance-identity.version>185.v303dc7c645f9</instance-identity.version>
+        <instance-identity.version>201.vd2a_b_5a_468a_a_6</instance-identity.version>
         <plugin-util-api.version>3.8.0</plugin-util-api.version>
         <commons-text-api.version>1.10.0-78.v3e7b_ea_d5a_fe1</commons-text-api.version>
         <workflow-support.version>865.v43e78cc44e0d</workflow-support.version>

--- a/pom.xml
+++ b/pom.xml
@@ -122,8 +122,8 @@
                         </goals>
                         <configuration>
                             <target>
-                                <exec executable="powershell.exe">
-                                    <arg value=".\GenerateHelpFiles.ps1 " />
+                                <exec executable="pwsh">
+                                    <arg value=".\GenerateHelpFiles.ps1 "/>
                                 </exec>
                             </target>
                         </configuration>


### PR DESCRIPTION
## What changed?
Change executable to pwsh to be OS agnostic instead of `powershell.exe` windows exclusive

## Why is this change necessary?
To unblock release 

## How has this been tested?
PR build on linux agent from security scan

## Are there any breaking changes?
- [X] None
- [ ] Input parameter renaming/removal
- [ ] New input parameter that changes the previous default behaviour
- [ ] Authentication option removal
- [ ] Changing the default CLI that come with breaking changes compared to the previous default CLI version