### PR TITLE
Jenkins: Update CLI version, make folder name optional to support Test Manager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <packaging>hpi</packaging>
 
     <properties>
-        <revision>6.0</revision>
+        <revision>6.1</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/uipath-automation-package-plugin</gitHubRepo>
         <jenkins.version>2.414.3</jenkins.version>

--- a/src/main/java/com/uipath/uipathpackage/UiPathInstallPlatform.java
+++ b/src/main/java/com/uipath/uipathpackage/UiPathInstallPlatform.java
@@ -75,7 +75,7 @@ public class UiPathInstallPlatform extends Builder implements SimpleBuildStep {
             FilePath actualCliNupkgPath = null;
 
             if (scopedVersion.contains("CustomVersion")) {
-                if(StringUtils.isBlank(cliNupkgPath)){
+                if (StringUtils.isBlank(cliNupkgPath)) {
                     throw new AbortException("CustomVersion is selected, but path to local nupkg is not provided.");
                 }
                 try {
@@ -90,8 +90,7 @@ public class UiPathInstallPlatform extends Builder implements SimpleBuildStep {
                     logger.println("Exception: " + e.getMessage());
                     throw new AbortException("Failed to parse custom CLI version from path: " + cliNupkgPath + ". Make sure you didn't change default nupkg name downloaded from feed");
                 }
-            }
-            else {
+            } else {
                 versionConfiguration = cliConfiguration.getConfiguration(scopedVersion);
             }
 
@@ -102,20 +101,20 @@ public class UiPathInstallPlatform extends Builder implements SimpleBuildStep {
 
             logger.println(isSelectedCliAlreadyCached ? "cli " + scopedVersion + " is already cached.." : "cli " + scopedVersion + " is not found in cache..");
 
-            if(this.forceInstall || !isSelectedCliAlreadyCached) {
-                if(forceInstall) {
+            if (this.forceInstall || !isSelectedCliAlreadyCached) {
+                if (forceInstall) {
                     logger.println("force installing the cli , any previous cache for version " + scopedVersion + " will be invalidated..");
                 }
 
                 FilePath cliRootCacheDirPath = cliConfiguration.getCliRootCachedDirectoryPath(launcher, envVars, scopedVersion);
 
-                if(scopedVersion.equals(cliConfiguration.getDefaultCliVersionKey())) {
+                if (scopedVersion.equals(cliConfiguration.getDefaultCliVersionKey())) {
                     logger.print("(caching) extracting the pre-packaged cli...");
                     util.extractCliApp(cliRootCacheDirPath, listener, envVars);
 
-                } else if(cliVersion.contains("CustomVersion") && StringUtils.isNotBlank(cliNupkgPath)) {
-                    if(!actualCliNupkgPath.exists()){
-                        logger.println("CliNupkgPath provided doesn't exists "+actualCliNupkgPath.getRemote());
+                } else if (cliVersion.contains("CustomVersion") && StringUtils.isNotBlank(cliNupkgPath)) {
+                    if (!actualCliNupkgPath.exists()) {
+                        logger.println("CliNupkgPath provided doesn't exists " + actualCliNupkgPath.getRemote());
                         throw new AbortException(Messages.UiPathInstallPlatform_DescriptorImpl_Error_CliNupkgPath());
                     }
                     logger.println("(caching) extracting provided cli-nuget from path " + actualCliNupkgPath.getRemote());
@@ -137,10 +136,10 @@ public class UiPathInstallPlatform extends Builder implements SimpleBuildStep {
 
             cliConfiguration.updateSelectedCliVersionKey(run, scopedVersion);
         } catch (Exception e) {
-            if(traceLevel.equals(TraceLevel.Verbose) || traceLevel.equals(TraceLevel.Error)) {
+            if (traceLevel.equals(TraceLevel.Verbose) || traceLevel.equals(TraceLevel.Error)) {
                 e.printStackTrace(logger);
             }
-            throw new AbortException("unable to install the cli "+ e.getMessage());
+            throw new AbortException("unable to install the cli " + e.getMessage());
         }
     }
 
@@ -168,6 +167,10 @@ public class UiPathInstallPlatform extends Builder implements SimpleBuildStep {
         } else if (osName.contains("linux")) {
             if (cliSelectedVersion.getPlatform() != UiPathCliConfiguration.CliPlatform.Linux) {
                 throw new AbortException("Selected UiPath CLI version '" + cliSelectedVersion.getDisplayName() + "' cannot be executed on Linux agent.");
+            }
+        } else if (osName.contains("darwin") || osName.contains("mac")) {
+            if (cliSelectedVersion.getPlatform() != UiPathCliConfiguration.CliPlatform.macOS) {
+                throw new AbortException("Selected UiPath CLI version '" + cliSelectedVersion.getDisplayName() + "' cannot be executed on macOS agent.");
             }
         } else {
             throw new AbortException("Running on incompatible operating system");
@@ -239,7 +242,7 @@ public class UiPathInstallPlatform extends Builder implements SimpleBuildStep {
                 return new ListBoxModel();
             }
 
-            ListBoxModel result= new ListBoxModel();
+            ListBoxModel result = new ListBoxModel();
 
             List<Map.Entry<String, UiPathCliConfiguration.Configuration>> entries =
                     new ArrayList<>(cliConfiguration.getConfiguration().entrySet());
@@ -247,11 +250,11 @@ public class UiPathInstallPlatform extends Builder implements SimpleBuildStep {
                             -> e.getValue().getName())
                     .thenComparing(e -> e.getValue().getVersion().getComplete(), Comparator.reverseOrder()));
 
-           for (Map.Entry<String, UiPathCliConfiguration.Configuration> v : entries) {
-               result.add(new ListBoxModel.Option(v.getValue().getDisplayName(), v.getKey()));
-           }
+            for (Map.Entry<String, UiPathCliConfiguration.Configuration> v : entries) {
+                result.add(new ListBoxModel.Option(v.getValue().getDisplayName(), v.getKey()));
+            }
 
-           return result;
+            return result;
         }
 
         public ListBoxModel doFillTraceLevelItems(@AncestorInPath Item item) {
@@ -259,8 +262,8 @@ public class UiPathInstallPlatform extends Builder implements SimpleBuildStep {
                 return new ListBoxModel();
             }
 
-            ListBoxModel result= new ListBoxModel();
-            for (TraceLevel v: TraceLevel.values()) {
+            ListBoxModel result = new ListBoxModel();
+            for (TraceLevel v : TraceLevel.values()) {
                 result.add(v.toString(), v.toString());
             }
 

--- a/src/main/java/com/uipath/uipathpackage/UiPathTest.java
+++ b/src/main/java/com/uipath/uipathpackage/UiPathTest.java
@@ -151,6 +151,7 @@ public class UiPathTest extends Recorder implements SimpleBuildStep, JUnitTask {
             if (!StringUtils.isBlank(projectKey)) {
                 testOptions.setProjectKey(projectKey.trim());
             } else {
+                testOptions.setOrganizationUnit(envVars.expand(folderName.trim()));
                 listener.getLogger().println("Testing module in Orchestrator will be deprecated soon. Consider migrating to UiPath Test Manager. " +
                         "For more information, visit: " +
                         "Migration FAQ: https://docs.uipath.com/orchestrator/automation-cloud/latest/user-guide/faq-migrating-test-artifacts-to-test-manager " +
@@ -181,16 +182,18 @@ public class UiPathTest extends Recorder implements SimpleBuildStep, JUnitTask {
                 }
             }
             else {
-                if(!StringUtils.isBlank(projectKey))
-                    testOptions.setTestSetKey(((TestSetEntry)testTarget).getTestSet());
-                else
-                    testOptions.setTestSet(((TestSetEntry)testTarget).getTestSet());
+                if(!StringUtils.isBlank(projectKey)) {
+                    testOptions.setTestSetKey(((TestSetEntry) testTarget).getTestSet());
+                }
+                else {
+                    testOptions.setTestSet(((TestSetEntry) testTarget).getTestSet());
+                }
             }
 
             String orchestratorTenantFormatted = envVars.expand(orchestratorTenant.trim()).isEmpty() ? util.getConfigValue(rb, "UiPath.DefaultTenant") : envVars.expand(orchestratorTenant.trim());
             testOptions.setOrchestratorUrl(orchestratorAddress);
             testOptions.setOrchestratorTenant(orchestratorTenantFormatted);
-            testOptions.setOrganizationUnit(envVars.expand(folderName.trim()));
+
             testOptions.setTestReportType("junit");
 
             String resultsOutputPath = testResultsOutputPath != null && !testResultsOutputPath.trim().isEmpty()
@@ -483,7 +486,9 @@ public class UiPathTest extends Recorder implements SimpleBuildStep, JUnitTask {
 
         Utility util = new Utility();
         util.validateParams(this.orchestratorAddress, com.uipath.uipathpackage.Messages.ValidationErrors_InvalidOrchAddress());
-        util.validateParams(this.folderName, com.uipath.uipathpackage.Messages.ValidationErrors_InvalidOrchFolder());
+
+        if(StringUtils.isBlank(projectKey))
+            util.validateParams(this.folderName, com.uipath.uipathpackage.Messages.ValidationErrors_InvalidOrchFolder());
 
         if (credentials == null) {
             throw new InvalidParameterException(com.uipath.uipathpackage.Messages.GenericErrors_MissingAuthenticationMethod());
@@ -667,19 +672,6 @@ public class UiPathTest extends Recorder implements SimpleBuildStep, JUnitTask {
         public FormValidation doCheckOrchestratorAddress(@QueryParameter String value) {
             if (value.trim().isEmpty()) {
                 return FormValidation.error(com.uipath.uipathpackage.Messages.GenericErrors_MissingOrchestratorAddress());
-            }
-            return FormValidation.ok();
-        }
-
-        /**
-         * Validates Orchestrator Folder
-         *
-         * @param value value of orchestrator folder
-         * @return FormValidation
-         */
-        public FormValidation doCheckFolderName(@QueryParameter String value) {
-            if (value.trim().isEmpty()) {
-                return FormValidation.error(com.uipath.uipathpackage.Messages.GenericErrors_MissingFolder());
             }
             return FormValidation.ok();
         }

--- a/src/main/resources/com/uipath/uipathpackage/UiPathTest/config.properties
+++ b/src/main/resources/com/uipath/uipathpackage/UiPathTest/config.properties
@@ -1,7 +1,7 @@
 PackagePath=Package(s) path
 OrchestratorAddress=Orchestrator address
 OrchestratorTenant=Orchestrator tenant
-OrchestratorFolder=Orchestrator folder
+OrchestratorFolder=Orchestrator folder (only for running in Orchestrator Testing Module)
 Credentials=Credentials
 AuthenticationToken=Authentication Token
 TestTarget=Target

--- a/src/main/resources/com/uipath/uipathpackage/UiPathTest/config_de.properties
+++ b/src/main/resources/com/uipath/uipathpackage/UiPathTest/config_de.properties
@@ -1,7 +1,7 @@
 PackagePath=Paketpfad
 OrchestratorAddress=Orchestrator-Adresse
 OrchestratorTenant=Orchestrator-Mandant
-OrchestratorFolder=Orchestrator-Ordner
+OrchestratorFolder=
 Credentials=Anmeldeinformationen
 AuthenticationToken=Authentifizierungstoken
 TestTarget=Target

--- a/src/main/resources/com/uipath/uipathpackage/UiPathTest/config_es-MX.properties
+++ b/src/main/resources/com/uipath/uipathpackage/UiPathTest/config_es-MX.properties
@@ -1,7 +1,7 @@
 PackagePath=Ruta de acceso a los paquetes
 OrchestratorAddress=Dirección de Orchestrator
 OrchestratorTenant=Inquilino de Orchestrator
-OrchestratorFolder=Carpeta de Orchestrator
+OrchestratorFolder=
 Credentials=Credenciales
 AuthenticationToken=Token de autenticación
 TestTarget=Target

--- a/src/main/resources/com/uipath/uipathpackage/UiPathTest/config_es.properties
+++ b/src/main/resources/com/uipath/uipathpackage/UiPathTest/config_es.properties
@@ -1,7 +1,7 @@
 PackagePath=Ruta de paquete/s
 OrchestratorAddress=Dirección de Orchestrator
 OrchestratorTenant=Inquilino de Orchestrator
-OrchestratorFolder=Carpeta de Orchestrator
+OrchestratorFolder=
 Credentials=Credenciales
 AuthenticationToken=Token de autenticación
 TestTarget=Destino

--- a/src/main/resources/com/uipath/uipathpackage/UiPathTest/config_fr.properties
+++ b/src/main/resources/com/uipath/uipathpackage/UiPathTest/config_fr.properties
@@ -1,7 +1,7 @@
 PackagePath=Chemin d’accès au(x) package(s)
 OrchestratorAddress=Adresse Orchestrator
 OrchestratorTenant=Locataire dʹOrchestrator
-OrchestratorFolder=Dossier Orchestrator
+OrchestratorFolder=
 Credentials=Identifiants
 AuthenticationToken=Jeton d’authentification
 TestTarget=Target

--- a/src/main/resources/com/uipath/uipathpackage/UiPathTest/config_ja.properties
+++ b/src/main/resources/com/uipath/uipathpackage/UiPathTest/config_ja.properties
@@ -1,7 +1,7 @@
 PackagePath=パッケージのパス
 OrchestratorAddress=Orchestrator のアドレス
 OrchestratorTenant=Orchestrator テナント
-OrchestratorFolder=Orchestrator のフォルダー
+OrchestratorFolder=
 Credentials=資格情報
 AuthenticationToken=認証トークン
 TestTarget=ターゲット

--- a/src/main/resources/com/uipath/uipathpackage/UiPathTest/config_ko.properties
+++ b/src/main/resources/com/uipath/uipathpackage/UiPathTest/config_ko.properties
@@ -1,7 +1,7 @@
 PackagePath=패키지 경로
 OrchestratorAddress=Orchestrator 주소
 OrchestratorTenant=Orchestrator 테넌트
-OrchestratorFolder=Orchestrator 폴더
+OrchestratorFolder=
 Credentials=자격 증명
 AuthenticationToken=인증 토큰
 TestTarget=Target

--- a/src/main/resources/com/uipath/uipathpackage/UiPathTest/config_pt-BR.properties
+++ b/src/main/resources/com/uipath/uipathpackage/UiPathTest/config_pt-BR.properties
@@ -1,7 +1,7 @@
 PackagePath=Caminho do(s) pacote(s)
 OrchestratorAddress=Endereço do Orchestrator
 OrchestratorTenant=Tenant do Orchestrator
-OrchestratorFolder=Pasta do Orchestrator
+OrchestratorFolder=
 Credentials=Credenciais
 AuthenticationToken=Token de Autenticação
 TestTarget=Target

--- a/src/main/resources/com/uipath/uipathpackage/UiPathTest/config_pt.properties
+++ b/src/main/resources/com/uipath/uipathpackage/UiPathTest/config_pt.properties
@@ -1,7 +1,7 @@
 PackagePath=Caminho do(s) pacote(s)
 OrchestratorAddress=Endereço do Orchestrator
 OrchestratorTenant=Inquilino do Orchestrator
-OrchestratorFolder=Pasta do Orchestrator
+OrchestratorFolder=
 Credentials=Credenciais
 AuthenticationToken=Token de autenticação
 TestTarget=Target

--- a/src/main/resources/com/uipath/uipathpackage/UiPathTest/config_ru.properties
+++ b/src/main/resources/com/uipath/uipathpackage/UiPathTest/config_ru.properties
@@ -1,7 +1,7 @@
 PackagePath=Путь к пакетам
 OrchestratorAddress=Адрес Orchestrator
 OrchestratorTenant=Тенант Orchestrator
-OrchestratorFolder=Orchestrator Folder
+OrchestratorFolder=
 Credentials=Учетные данные
 AuthenticationToken=Маркер проверки подлинности
 TestTarget=Target

--- a/src/main/resources/com/uipath/uipathpackage/UiPathTest/config_tr.properties
+++ b/src/main/resources/com/uipath/uipathpackage/UiPathTest/config_tr.properties
@@ -1,7 +1,7 @@
 PackagePath=Paket yolu
 OrchestratorAddress=Orchestrator adresi
 OrchestratorTenant=Orchestrator Kiracısı
-OrchestratorFolder=Orchestrator klasörü
+OrchestratorFolder=
 Credentials=Kimlik Bilgileri
 AuthenticationToken=Kimlik Doğrulama Belirteci
 TestTarget=Target

--- a/src/main/resources/com/uipath/uipathpackage/UiPathTest/config_zh-CN.properties
+++ b/src/main/resources/com/uipath/uipathpackage/UiPathTest/config_zh-CN.properties
@@ -1,7 +1,7 @@
 PackagePath=包路径
 OrchestratorAddress=Orchestrator 地址
 OrchestratorTenant=Orchestrator 租户
-OrchestratorFolder=Orchestrator 文件夹
+OrchestratorFolder=
 Credentials=凭据
 AuthenticationToken=身份验证令牌
 TestTarget=目标

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -1,5 +1,5 @@
-UiPath.CLI.Version=25.10.1-20251105-9
+UiPath.CLI.Version=25.10.3
 UiPath.DefaultTenant=default
 UiPath.CLI.Name=UiPath.CLI.Windows
-UiPath.CLI.InstallPlatform.Configuration=["CustomVersion","Linux.25.10.3","Windows.25.10.3", "macOS.25.10.3", "Windows.Legacy.25.10.9424.14050"]
-UiPath.CLI.InstallPlatform.Configuration.Count=4
+UiPath.CLI.InstallPlatform.Configuration=["CustomVersion","Linux.25.10.3", "Linux.25.10.1-20251105-9", "Windows.25.10.3", "Windows.25.10.1-20251105-9", "macOS.25.10.3", "Windows.Legacy.25.10.9424.14050"]
+UiPath.CLI.InstallPlatform.Configuration.Count=7

--- a/stage.test.yml
+++ b/stage.test.yml
@@ -22,6 +22,8 @@ stages:
           configurationName: 'JenkinsE2ETests/UiPathSolution/SolutionUploadPackageAndDeploySuccess'
         - jobName: 'SolutionPackUploadAndDeploySuccess'
           configurationName: 'JenkinsE2ETests/UiPathSolution/SolutionPackUploadAndDeploySuccess'
+        - jobName: 'SolutionPackWithCertificateSigning'
+          configurationName: 'JenkinsE2ETests/UiPathSolution/SolutionPackWithCertificateSigning'
         #### CLIVersion E2E tests ###
         - jobName: 'UiPathTasksExtractPrepackagedCLI'
           configurationName: 'JenkinsE2ETests/CLIVersion/UiPathTasksExtractPrepackagedCLI'
@@ -68,10 +70,13 @@ stages:
           configurationName: 'JenkinsE2ETests/UiPathPack/PackWithOrchestratorDependencies'
         - jobName: 'PackWithRepositoryMetadata'
           configurationName: 'JenkinsE2ETests/UiPathPack/PackWithRepositoryMetadata'
-        - jobName: 'PackShouldNotLookUpInBuiltInFeeds'
-          configurationName: 'JenkinsE2ETests/UiPathPack/PackShouldNotLookUpInBuiltInFeeds'
+#       This test clears uipath.activities.runtimegovernance, but since other tests might pack as well in parallel, assembly's folder is restored (opened STUD-78424)
+#        - jobName: 'PackShouldNotLookUpInBuiltInFeeds'
+#          configurationName: 'JenkinsE2ETests/UiPathPack/PackShouldNotLookUpInBuiltInFeeds'
         - jobName: 'AnalyzeShouldUseGovernanceFile'
           configurationName: 'JenkinsE2ETests/UiPathPack/AnalyzeShouldUseGovernanceFile'
+        - jobName: 'PackWithCertificateSigning'
+          configurationName: 'JenkinsE2ETests/UiPathPack/PackWithCertificateSigning'
         #### UiPathRunJob E2E tests ###
         - jobName: 'RunJobFailsWhenORJobFails'
           configurationName: 'JenkinsE2ETests/UiPathRunJob/RunJobFailsWhenORJobFails'
@@ -104,6 +109,8 @@ stages:
           configurationName: 'JenkinsE2ETests/UiPathTest/RunTransientTestPackagedWithRepositoryMetadata'
         - jobName: 'RunTestShouldNotLookUpInBuiltInFeeds'
           configurationName: 'JenkinsE2ETests/UiPathTest/RunTestShouldNotLookUpInBuiltInFeeds'
+        - jobName: 'RunTestSetFromTestManager'
+          configurationName: 'JenkinsE2ETests/UiPathTest/RunTestSetFromTestManager'
         #### JenkinsPipelineTypes E2E tests ###
 #        - jobName: 'FreestylePipeline'
 #          configurationName: 'JenkinsE2ETests/JenkinsPipelineTypes/FreestylePipeline'


### PR DESCRIPTION
Added 25.10.3 as default version for UipCLI.
Make orchestrator folder optional when using Test Manager.
Add logic that validates cli version for macOS.
Removed PackShouldNotLookUpInBuiltInFeeds test which fails due to other pack tests running in parallel: [STUD-78424](https://uipath.atlassian.net/browse/STUD-78424?search_id=f1c1429d-dfcb-4559-8b9b-a04355e2f269)
Added new tests for package signing and test manager

Pipeline with e2e tests [here](https://uipath.visualstudio.com/Plugins.Jenkins/_build/results?buildId=10622048&view=results)

https://uipath.atlassian.net/browse/STUD-78412